### PR TITLE
Clean out expired sessions from database regularly

### DIFF
--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -76,7 +76,7 @@ module.exports = function(connect) {
                 self.client.emit('connect');
 
                 dbCleanup(self);
-                setInterval(dbCleanup, oneDay, self);
+                setInterval(dbCleanup, oneDay, self).unref();
             }
         );
     }


### PR DESCRIPTION
This code makes it so expired sessions are regularly removed from the database so they don't stay in it forever. The cleaning happens immediately when the SQLiteStore is initialized, and then once a day.
