### PR TITLE
Add support for Express 4.x

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,9 +23,14 @@ connect-sqlite3 is a SQLite3 session store modeled after the TJ's connect-redis 
       connect.session({ store: new SQLiteStore, secret: 'your secret' })
     );
 
-  with express    
+  with express
 
+    3.x:
     var SQLiteStore = require('connect-sqlite3')(express);
+
+    4.x:
+    var session = require('express-session');
+    var SQLiteStore = require('connect-sqlite3')(session);
 
     app.configure(function() {
       app.set('views', __dirname + '/views');

--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -32,7 +32,7 @@ module.exports = function(connect) {
     * Connect's Store.
     */
 
-    var Store = connect.session.Store;
+    var Store = (connect.session) ? connect.session.Store : connect.Store;
 
     /**
     * Remove expired sessions from database.


### PR DESCRIPTION
Express 4.x no longer includes most of its middleware, so the express-session object must be passed directly.
