### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "David Feinberg",
   "main": "lib/connect-sqlite3",
   "dependencies": {
-    "sqlite3": "git+https://github.com/developmentseed/node-sqlite3.git"
+    "sqlite3": "git+https://github.com/mapbox/node-sqlite3.git"
   },
   "devDependencies": {
     "connect": ">=1.0.0"


### PR DESCRIPTION
Connect-SQLite3 was moved from DevelopmentSeed to MapBox... This might fix the error on Cloud9IDE where this package cannot be installed.