### PR TITLE
added touch protocol

### DIFF
--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -175,6 +175,32 @@ module.exports = function(connect) {
             fn(null, true);
         });
     };
+    
+    
+    /**
+    * Touch the given session object associated with the given session ID.
+    *
+    * @param {string} sid
+    * @param {object} session
+    * @param {function} fn
+    * @public
+    */
+    SQLiteStore.prototype.touch = function(sid, session, fn) {
+        if (session && session.cookie && session.cookie.expires) {
+            var now = new Date().getTime();
+            var cookieExpires = new Date(session.cookie.expires).getTime();
+            this.db.run('UPDATE ' + this.table + ' SET expired=? WHERE sid = ? AND ? <= expired',
+                [cookieExpires, sid, now],
+                function(err) {
+                    if (fn) {
+                        if (err) fn(err);
+                        fn(null, true);
+                    }
+                }
+            );
+        }
+    }
+    
 
     return SQLiteStore;
 


### PR DESCRIPTION
There's an option in [express-session](https://github.com/expressjs/session) called "rolling", that only works if the `sessionStore` supports the `touch()` protocol.