### PR TITLE
Reference latest packaged sqlite instead of last revision

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "David Feinberg",
   "main": "lib/connect-sqlite3",
   "dependencies": {
-    "sqlite3": "git+https://github.com/mapbox/node-sqlite3.git"
+    "sqlite3": "^3.1.1"
   },
   "devDependencies": {
     "connect": ">=1.0.0"


### PR DESCRIPTION
This failed before on npm install

  "dependencies": {
    "connect-sqlite3": "^0.9.5",
    "sqlite3": "^3.1.1"
  }

With the error:
npm ERR! Windows_NT 6.1.7601
npm ERR! argv "C:\\Program Files\\nodejs\\\\node.exe" "C:\\Program Files\\nodejs
\\node_modules\\npm\\bin\\npm-cli.js" "install" "--production"
npm ERR! node v0.10.33
npm ERR! npm  v3.3.12
npm ERR! path C:\Users\VALVI\nodetmp\node_modules\sqlite3\node_modules\node-pre-
gyp\node_modules\mkdirp\bin\cmd.js
npm ERR! code ENOENT
npm ERR! errno 34

npm ERR! enoent ENOENT, chmod 'C:\Users\VALVI\nodetmp\node_modules\sqlite3\node_
modules\node-pre-gyp\node_modules\mkdirp\bin\cmd.js'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent