### PR TITLE
Handle shared cache stores

### DIFF
--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -60,13 +60,13 @@ module.exports = function(connect) {
         this.db = options.db || this.table;
         var dbPath;
 
-        if(this.db !== ':memory:') {
-            dbPath = (options.dir || '.') + '/' + this.db + '.db';
-        } else {
+        if (this.db.indexOf(':memory:') > -1 || this.db.indexOf('?mode=memory') > -1) {
             dbPath = this.db;
+        } else {
+            dbPath = (options.dir || '.') + '/' + this.db + '.db';
         }
-
-        this.db = new sqlite3.Database(dbPath);
+        
+        this.db = new sqlite3.Database(dbPath, options.mode);
         this.client = new events.EventEmitter();
         var self = this;
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,17 @@
   "version": "0.9.6",
   "author": "David Feinberg",
   "main": "lib/connect-sqlite3",
+  "scripts": {
+    "test": "mocha test/test.js"
+  },
   "dependencies": {
     "sqlite3": "^3.1.1"
   },
   "devDependencies": {
-    "connect": ">=1.0.0"
+    "connect": ">=1.0.0",
+    "express-session": "^1.13.0",
+    "mocha": "^2.3.4",
+    "should": "^8.2.0"
   },
   "engines": {
     "node": ">=0.4.x"


### PR DESCRIPTION
Which means passing through db names like file::memory:?cache=shared as well as passing through mode so shared-cache mode can be enabled.

Also update the test to use connect-session instead of the outdated connect.session store.

Add mocha and should as well as connect-expression to dev dependencies, add a test runner for the nodejs tests.