### PR TITLE
resolve rawberg/connect-sqlite3#11: server hang due to missing callba…

### DIFF
--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -198,7 +198,9 @@ module.exports = function(connect) {
                     }
                 }
             );
-        }
+        } else {
+	    fn(null, true);
+	}
     }
     
 


### PR DESCRIPTION
…ck invocation in `touch`

See express-session's implementation: https://github.com/expressjs/session/blob/master/index.js#L303

The callback needs to be invoked in all calls to `touch`, or else `writeend` is never called inside express-session's `end` method, which finishes the response. In connect-sqlite3's `touch` method, the callback was not invoked if the cookie wasn't set to expire (which happens when no maxAge is set for the cookie, or with resave=false in the connect-sqlite3 configuration). This resulted in a browser hang and an `ERR_CONTENT_LENGTH_MISMATCH` due to a missing chunk at the end of the response.

This patch fixes that by invoking the `touch` callback even if the db doesn't require an update.