### PR TITLE
replaced deprecated inheritance statement

### DIFF
--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -85,8 +85,9 @@ module.exports = function(connect) {
     * Inherit from Store.
     */
 
-    SQLiteStore.prototype.__proto__ = Store.prototype;
-
+      SQLiteStore.prototype = Object.create(Store.prototype);
+      SQLiteStore.prototype.constructor = SQLiteStore;
+      
     /**
     * Attempt to fetch session by the given sid.
     *


### PR DESCRIPTION
the use of \_\_proto\_\_ brings with it significant performance issues and have since been deprecated. The use of Object.create is encouraged.

[Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/proto)