### PR TITLE
Use WAL mode for the database

### DIFF
--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -70,7 +70,7 @@ module.exports = function(connect) {
         this.client = new events.EventEmitter();
         var self = this;
 
-        this.db.exec('PRAGMA journal_mode = wal; CREATE TABLE IF NOT EXISTS ' + this.table + ' (' + 'sid PRIMARY KEY, ' + 'expired, sess)',
+        this.db.exec((options.concurrentDb ? 'PRAGMA journal_mode = wal; ' : '') + 'CREATE TABLE IF NOT EXISTS ' + this.table + ' (' + 'sid PRIMARY KEY, ' + 'expired, sess)',
             function(err) {
                 if (err) throw err;
                 self.client.emit('connect');

--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -70,7 +70,7 @@ module.exports = function(connect) {
         this.client = new events.EventEmitter();
         var self = this;
 
-        this.db.exec('CREATE TABLE IF NOT EXISTS ' + this.table + ' (' + 'sid PRIMARY KEY, ' + 'expired, sess)',
+        this.db.exec('PRAGMA journal_mode = wal; CREATE TABLE IF NOT EXISTS ' + this.table + ' (' + 'sid PRIMARY KEY, ' + 'expired, sess)',
             function(err) {
                 if (err) throw err;
                 self.client.emit('connect');


### PR DESCRIPTION
Fixes #15 

Untested, and it splits the database file into 3 files. Perhaps this should be optional?