### PR TITLE
Remove database file extension

### DIFF
--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -63,7 +63,7 @@ module.exports = function(connect) {
         if (this.db.indexOf(':memory:') > -1 || this.db.indexOf('?mode=memory') > -1) {
             dbPath = this.db;
         } else {
-            dbPath = (options.dir || '.') + '/' + this.db + '.db';
+            dbPath = (options.dir || '.') + '/' + this.db;
         }
         
         this.db = new sqlite3.Database(dbPath, options.mode);

--- a/lib/connect-sqlite3.js
+++ b/lib/connect-sqlite3.js
@@ -1,57 +1,50 @@
-/*
-* Connect - SQLite3
-* Copyright(c) 2012 David Feinberg
-* MIT Licensed
-* forked from https://github.com/tnantoka/connect-sqlite
-*/
+/**
+ * Connect - SQLite3
+ * Copyright(c) 2012 David Feinberg
+ * MIT Licensed
+ * forked from https://github.com/tnantoka/connect-sqlite
+ */
 
 /**
-* Module dependencies.
-*/
-
+ * Module dependencies.
+ */
 var sqlite3 = require('sqlite3'),
     events = require('events');
 
 /**
-* One day in milliseconds.
-*/
-
+ * @type {Integer}  One day in milliseconds.
+ */
 var oneDay = 86400000;
 
 /**
-* Return the SQLiteStore extending connect's session Store.
-*
-* @param {object} connect
-* @return {Function}
-* @api public
-*/
-
+ * Return the SQLiteStore extending connect's session Store.
+ *
+ * @param   {object}    connect
+ * @return  {Function}
+ * @api     public
+ */
 module.exports = function(connect) {
-
     /**
-    * Connect's Store.
-    */
-
+     * Connect's Store.
+     */
     var Store = (connect.session) ? connect.session.Store : connect.Store;
 
     /**
-    * Remove expired sessions from database.
-    * @param {Object} store
-    * @api private
-    */
-
+     * Remove expired sessions from database.
+     * @param   {Object}    store
+     * @api     private
+     */
     function dbCleanup(store) {
         var now = new Date().getTime();
         store.db.run('DELETE FROM ' + store.table + ' WHERE ? > expired', [now]);
     }
 
     /**
-    * Initialize SQLiteStore with the given options.
-    *
-    * @param {Object} options
-    * @api public
-    */
-
+     * Initialize SQLiteStore with the given options.
+     *
+     * @param   {Object}    options
+     * @api     public
+     */
     function SQLiteStore(options) {
         options = options || {};
         Store.call(this, options);
@@ -80,22 +73,20 @@ module.exports = function(connect) {
             }
         );
     }
-  
-    /**
-    * Inherit from Store.
-    */
 
-      SQLiteStore.prototype = Object.create(Store.prototype);
-      SQLiteStore.prototype.constructor = SQLiteStore;
-      
     /**
-    * Attempt to fetch session by the given sid.
-    *
-    * @param {String} sid
-    * @param {Function} fn
-    * @api public
-    */
+     * Inherit from Store.
+     */
+    SQLiteStore.prototype = Object.create(Store.prototype);
+    SQLiteStore.prototype.constructor = SQLiteStore;
 
+    /**
+     * Attempt to fetch session by the given sid.
+     *
+     * @param   {String}    sid
+     * @param   {Function}  fn
+     * @api     public
+     */
     SQLiteStore.prototype.get = function(sid, fn) {
         var now = new Date().getTime();
         this.db.get('SELECT sess FROM ' + this.table + ' WHERE sid = ? AND ? <= expired', [sid, now],
@@ -107,54 +98,48 @@ module.exports = function(connect) {
         );
     };
 
+    /**
+     * Commit the given `sess` object associated with the given `sid`.
+     *
+     * @param   {String}    sid
+     * @param   {Session}   sess
+     * @param   {Function}  fn
+     * @api     public
+     */
+    SQLiteStore.prototype.set = function(sid, sess, fn) {
+        try {
+            var maxAge = sess.cookie.maxAge;
+            var now = new Date().getTime();
+            var expired = maxAge ? now + maxAge : now + oneDay;
+            sess = JSON.stringify(sess);
 
-  /**
-   * Commit the given `sess` object associated with the given `sid`.
-   *
-   * @param {String} sid
-   * @param {Session} sess
-   * @param {Function} fn
-   * @api public
-   */
-
-  SQLiteStore.prototype.set = function(sid, sess, fn) {
-    try {
-      var maxAge = sess.cookie.maxAge;
-      var now = new Date().getTime();
-      var expired = maxAge ? now + maxAge : now + oneDay;
-      sess = JSON.stringify(sess);
-
-      this.db.all('INSERT OR REPLACE INTO ' + this.table + ' VALUES (?, ?, ?)',
-        [sid, expired, sess],
-        function(err, rows) {
-          if (fn) fn.apply(this, arguments);
+            this.db.all('INSERT OR REPLACE INTO ' + this.table + ' VALUES (?, ?, ?)',
+                [sid, expired, sess],
+                function(err, rows) {
+                    if (fn) fn.apply(this, arguments);
+                }
+            );
+        } catch (e) {
+            if (fn) fn(e);
         }
-      );
-    } catch (e) {
-      if (fn) fn(e);
-    }
-  };
-
+    };
 
     /**
-    * Destroy the session associated with the given `sid`.
-    *
-    * @param {String} sid
-    * @api public
-    */
-
+     * Destroy the session associated with the given `sid`.
+     *
+     * @param   {String}    sid
+     * @api     public
+     */
     SQLiteStore.prototype.destroy = function(sid, fn) {
         this.db.run('DELETE FROM ' + this.table + ' WHERE sid = ?', [sid], fn);
     };
 
-
     /**
-    * Fetch number of sessions.
-    *
-    * @param {Function} fn
-    * @api public
-    */
-
+     * Fetch number of sessions.
+     *
+     * @param   {Function}  fn
+     * @api     public
+     */
     SQLiteStore.prototype.length = function(fn) {
         this.db.all('SELECT COUNT(*) AS count FROM ' + this.table + '', function(err, rows) {
             if (err) fn(err);
@@ -162,30 +147,27 @@ module.exports = function(connect) {
         });
     };
 
-
     /**
-    * Clear all sessions.
-    *
-    * @param {Function} fn
-    * @api public
-    */
-
+     * Clear all sessions.
+     *
+     * @param   {Function}  fn
+     * @api     public
+     */
     SQLiteStore.prototype.clear = function(fn) {
         this.db.exec('DELETE FROM ' + this.table + '', function(err) {
             if (err) fn(err);
             fn(null, true);
         });
     };
-    
-    
+
     /**
-    * Touch the given session object associated with the given session ID.
-    *
-    * @param {string} sid
-    * @param {object} session
-    * @param {function} fn
-    * @public
-    */
+     * Touch the given session object associated with the given session ID.
+     *
+     * @param   {string}    sid
+     * @param   {object}    session
+     * @param   {function}  fn
+     * @public
+     */
     SQLiteStore.prototype.touch = function(sid, session, fn) {
         if (session && session.cookie && session.cookie.expires) {
             var now = new Date().getTime();
@@ -200,11 +182,9 @@ module.exports = function(connect) {
                 }
             );
         } else {
-	    fn(null, true);
-	}
+           fn(null, true);
+        }
     }
-    
 
     return SQLiteStore;
-
 };


### PR DESCRIPTION
Hi,
I did remove the `.db` suffix from database file name. Forcing this file extension prevents a single database to be used per application unless this database already has the `.db` suffix on it's file name (the exact scenario that triggered this pull request).

I did also fix the JSDoc, extra empty spaces and indentation (the coding style was kept unchanged).

Regards,
Paulo A. Silva