### PR TITLE
chore: use HTTPS package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/rawberg/connect-sqlite3.git"
+    "url": "https://github.com/rawberg/connect-sqlite3.git"
   },
   "licenses": [
     {


### PR DESCRIPTION
Updates package metadata to use HTTPS GitHub URLs instead of legacy unauthenticated URLs.

Validation:
- `git diff --check`
- parsed `package.json` with Node.js